### PR TITLE
fix/addGeocoderControl

### DIFF
--- a/app/map/map.tsx
+++ b/app/map/map.tsx
@@ -68,7 +68,6 @@ export default function ReactMap(Places: any) {
     geocoder.current.on("clear", function () {
       setGeocoderPlaces(null);
     });
-    mapRef.current?.getMap().addControl(geocoder.current);
   }, [map, customData]);
 
   useEffect(() => {
@@ -93,6 +92,11 @@ export default function ReactMap(Places: any) {
     });
   }, []);
 
+  const addGeocoderControl = useCallback(() => {
+    const map = mapRef.current?.getMap();
+    map?.addControl(geocoder.current);
+  }, []);
+
   const selectedPlace = (hoverInfo && hoverInfo.place) || null;
 
   return (
@@ -107,6 +111,7 @@ export default function ReactMap(Places: any) {
         mapboxAccessToken={MAPBOX_TOKEN}
         interactiveLayerIds={[placesLayer.id as string]}
         onMouseMove={onHover}
+        onLoad={addGeocoderControl}
         ref={mapRef}
       >
         <GeolocateControl position="top-left" />


### PR DESCRIPTION
# Problema

Buscador solo se agrega/aparece al interactuar con el mapa. No se agrega debido a que _mapRef_ no existe hasta montarse.

## Solución

El componente `<Map>` tiene un prop _onLoad_ el cual puede recibir una función que agregue la searchbar. Así al renderizarse el mapa queda seteado el _mapRef_ y permite agregarle el control durante el callback.

- addGeocoderControl callback function
- onLoad={addGeocoderControl} prop


## Resuelve

Esta pull request resuelve la issue ... (en trello 👎 )
