### PR TITLE
feat/map-dark-mode

### DIFF
--- a/app/map/layers.ts
+++ b/app/map/layers.ts
@@ -17,7 +17,7 @@ export const placesLayer: LayerProps = {
       "#0ef305",
       "other",
       "#e55e5e",
-      "#ccc",
+      "#808080",
     ],
     "circle-radius": 5,
   },

--- a/app/map/map.tsx
+++ b/app/map/map.tsx
@@ -18,6 +18,7 @@ import {
 import getGeocoder from "@/utils/getGeocoder";
 
 import geojson from "../../data/places.json";
+import { useThemeObserver } from "../../utils/themeObserver";
 import { useSearchResultCtx } from "../context/SearchResultCtx";
 
 import { placesLayer } from "./layers";
@@ -30,6 +31,9 @@ export default function ReactMap(Places: any) {
   const geocoder = useRef<any>(null);
   const [geocoderPlaces, setGeocoderPlaces] = useState<any>(null);
   const [hoverInfo, setHoverInfo] = useState<any>(null);
+  const [theme, setTheme] = useState(
+    typeof window !== "undefined" && localStorage?.theme === "dark" ? "dark-v11" : "streets-v11",
+  );
   const { searchResult, setSearchResult, initialLat, setInitialLat, initialLng, setInitialLng } = useSearchResultCtx();
 
   const customData = geojson;
@@ -37,6 +41,13 @@ export default function ReactMap(Places: any) {
 
   const setSearchResultRef = useRef(setSearchResult);
   setSearchResultRef.current = setSearchResult;
+
+  const onThemeChange = (isDark: boolean) => {
+    setTheme(isDark ? "dark-v11" : "streets-v11");
+    mapRef.current?.getMap().setStyle(`mapbox://styles/mapbox/${isDark ? "dark-v11" : "streets-v11"}`);
+  };
+
+  useThemeObserver(onThemeChange);
 
   useEffect(() => {
     geocoder.current = getGeocoder();
@@ -107,7 +118,7 @@ export default function ReactMap(Places: any) {
           latitude: initialLat,
           zoom: initialLat === -33.4983 && initialLng === -70.6109 ? 16 : 18,
         }}
-        mapStyle="mapbox://styles/mapbox/dark-v11"
+        mapStyle={`mapbox://styles/mapbox/${theme}`}
         mapboxAccessToken={MAPBOX_TOKEN}
         interactiveLayerIds={[placesLayer.id as string]}
         onMouseMove={onHover}

--- a/utils/themeObserver.tsx
+++ b/utils/themeObserver.tsx
@@ -1,0 +1,22 @@
+// themeObserver.ts
+import { useCallback, useEffect, useRef } from "react";
+
+export const useThemeObserver = (onThemeChange: (isDark: boolean) => void) => {
+  const observer = useRef<MutationObserver | null>(null);
+
+  const onClassChange = useCallback(() => {
+    if (typeof window !== "undefined") {
+      const isDark = document.documentElement.classList.contains("dark");
+      onThemeChange(isDark);
+    }
+  }, [onThemeChange]);
+
+  useEffect(() => {
+    observer.current = new MutationObserver(onClassChange);
+    observer.current.observe(document.documentElement, { attributes: true, attributeFilter: ["class"] });
+
+    return () => {
+      observer.current?.disconnect();
+    };
+  }, [onClassChange]);
+};


### PR DESCRIPTION
# Problema

se debe cambiar el estilo del mapa de acorde al dark mode.

## Solución

Se implementó un observer para llamar a la función que cambia el estilo del mapa cuando el root element sufre un cambio en su _class_

- Cambio al estilo del modo claro (streets-v11) para hacer más visible cada parte del campus.
- Cambio de color de la categoría "otros" para los puntos, ya que coincidía con el modo claro y estos se volvían invisibles.

## Resuelve

Esta pull request resuelve la issue #(trello: mapa on dark mode)
