### PR TITLE
fix/invisible-marker

### DIFF
--- a/app/map/marker.tsx
+++ b/app/map/marker.tsx
@@ -5,7 +5,7 @@ import { Marker as MapboxMarker } from "react-map-gl";
 export default function Marker({ place }: { place: any }) {
   return (
     <MapboxMarker latitude={place.geometry.coordinates[1]} longitude={place.geometry.coordinates[0]} offset={[0, -18]}>
-      <Image className="" src="/logo-white.svg" alt="Logo" width={20} height={20} />
+      <Image className="dark:invert" src="/logo.svg" alt="Logo" width={20} height={20} />
     </MapboxMarker>
   );
 }


### PR DESCRIPTION
# Problema

Pin de resultado de búsqueda tiene mismo color de mapa en modo claro. No se veía.

## Solución

Se usa el logo en forma default (oscuro) y se le aplica dark:invert en su clase.
