### PR TITLE
fix/addGeocoderControl-refactor

### DIFF
--- a/app/map/map.tsx
+++ b/app/map/map.tsx
@@ -95,8 +95,8 @@ export default function MapComponent({ Places }: any) {
   }, []);
 
   const addGeocoderControl = useCallback(() => {
-    map?.addControl(geocoder.current);
-  }, [map]);
+    mapRef.current?.addControl(geocoder.current);
+  }, []);
 
   const selectedPlace = (hoverInfo && hoverInfo.place) || null;
   return (


### PR DESCRIPTION
# Problema

Geocoder nuevamente no se agregaba al cargar el mapa. 

## Solución

addGeocoderControl toma el mapRef en vez del mapa directamente. Debido a que este último no existe en el momento preciso.


## Resuelve

Esta pull request resuelve la issue #(nuevo bug d en el buscador esde último refactor)
