### PR TITLE
Fix/map add params refresh when search place

### DIFF
--- a/app/map/placeHandlers.ts
+++ b/app/map/placeHandlers.ts
@@ -6,6 +6,7 @@ export const handleResult = (result: any, setGeocoderPlaces: (places: any[]) => 
       break;
     }
   }
+  window.history.replaceState(null, "", `?place=${selectedPlaceId}`);
 };
 
 export const handleResults = (results: any, setGeocoderPlaces: (places: any[]) => void, Places: any) => {


### PR DESCRIPTION
# Problema

No se actualiza la sala en la url al buscar salas.

## Solución

- Agregar [replaceState](https://nextjs.org/docs/app/building-your-application/routing/linking-and-navigating#using-the-native-history-api) al handler de resultado del geocoder.

## Resuelve

Esta pull request resuelve la issue #90
