### PR TITLE
Route hotfix

### DIFF
--- a/app/components/directions/fetchDirection.tsx
+++ b/app/components/directions/fetchDirection.tsx
@@ -3,9 +3,10 @@ import { LineFeature } from "@/utils/types";
 export const fetchDirection = async (
   start: [number, number],
   end: [number, number],
+  walkwayBias: number,
 ): Promise<{ direction: LineFeature; duration: number; distance: number }> => {
   const response = await fetch(
-    `https://api.mapbox.com/directions/v5/mapbox/walking/${start[0]},${start[1]};${end[0]},${end[1]}?geometries=geojson&steps=true&access_token=${process.env.NEXT_PUBLIC_MAPBOX_TOKEN}&overview=full`,
+    `https://api.mapbox.com/directions/v5/mapbox/walking/${start[0]},${start[1]};${end[0]},${end[1]}?geometries=geojson&steps=true&access_token=${process.env.NEXT_PUBLIC_MAPBOX_TOKEN}&walkway_bias=${walkwayBias}`,
     {
       cache: "force-cache",
     },

--- a/app/components/directions/fetchDirection.tsx
+++ b/app/components/directions/fetchDirection.tsx
@@ -5,7 +5,7 @@ export const fetchDirection = async (
   end: [number, number],
 ): Promise<{ direction: LineFeature; duration: number; distance: number }> => {
   const response = await fetch(
-    `https://api.mapbox.com/directions/v5/mapbox/walking/${start[0]},${start[1]};${end[0]},${end[1]}?geometries=geojson&steps=true&access_token=${process.env.NEXT_PUBLIC_MAPBOX_TOKEN}`,
+    `https://api.mapbox.com/directions/v5/mapbox/walking/${start[0]},${start[1]};${end[0]},${end[1]}?geometries=geojson&steps=true&access_token=${process.env.NEXT_PUBLIC_MAPBOX_TOKEN}&overview=full`,
     {
       cache: "force-cache",
     },

--- a/app/components/directions/routeButton.tsx
+++ b/app/components/directions/routeButton.tsx
@@ -24,11 +24,7 @@ const getOptimalDirection = async (origin: [number, number], destination: [numbe
 
   const [defaultDirection, biasedDirection] = results;
 
-  if (
-    biasedDirection.duration &&
-    defaultDirection.duration &&
-    biasedDirection.duration < defaultDirection.duration
-  ) {
+  if (biasedDirection.duration && defaultDirection.duration && biasedDirection.duration < defaultDirection.duration) {
     return biasedDirection;
   }
 


### PR DESCRIPTION
# Problema
Las rutas a veces no tomaban en cuenta calles del campus, así que no eran óptimas.


## Solución
Obtener una segunda ruta de la API cambiando el parametro [walkway_bias](https://docs.mapbox.com/api/navigation/directions/#optional-parameters-for-the-mapboxwalking-profile), el que aumenta la preferencia para usar calles para caminar.

