### PR TITLE
Fix: Se actualiza zoom-out de Campus Villarrica

### DIFF
--- a/app/styles/themes/uc-theme.css
+++ b/app/styles/themes/uc-theme.css
@@ -15,7 +15,7 @@
   --theme-tertiary: var(--palette-soft-gray-200);
   --theme-tertiary-foreground: var(--palette-uc-blanco);
   
-  --theme-muted: var(--palette-uc-gris-claro-b);
+  --theme-muted: var(--palette-uc-gris-oscuro-a);
   --theme-muted-foreground: var(--palette-uc-gris-oscuro-b);
   
   --theme-accent: var(--palette-uc-azul);

--- a/lib/campus/getCampusBounds.tsx
+++ b/lib/campus/getCampusBounds.tsx
@@ -30,8 +30,8 @@ const campusMaxBounds: Record<string, CampusBounds> = {
     latitudeRange: [-33.4286518, -33.4065652],
   },
   VR: {
-    longitudeRange: [-72.22701952051408, -72.2242192943034],
-    latitudeRange: [-39.278605924710156, -39.276849411532424],
+    longitudeRange: [-72.232, -72.218],
+    latitudeRange: [-39.282, -39.273],
   },
   CC: {
     longitudeRange: [-70.6470478, -70.6323672],
@@ -50,8 +50,8 @@ const campusMaxBounds: Record<string, CampusBounds> = {
     latitudeRange: [-33.4286518, -33.4065652],
   },
   Villarrica: {
-    longitudeRange: [-72.22701952051408, -72.2242192943034],
-    latitudeRange: [-39.278605924710156, -39.276849411532424],
+    longitudeRange: [-72.232, -72.218],
+    latitudeRange: [-39.282, -39.273],
   },
   CasaCentral: {
     longitudeRange: [-70.6470478, -70.6323672],


### PR DESCRIPTION
# Problema
1. Campus Villarrica es mas grande de lo indicado en el polígono registrado (Cuenta con varios establecimientos).
2. Botón de "Centrar mapa en mi ubicación" no se ve cuando entra en --theme-muted ya que el mapa es blanco.

## Solución
1. De manera provisoria, se extiende el zoom-out de Campus Villarrica para poder ver sus establecimientos.
2. Se oscurece el --theme-muted para poder verlo en contraste con el mapa.

