### PR TITLE
Fix: Color de indicador de ubicación

### DIFF
--- a/app/styles/themes/uc-theme.css
+++ b/app/styles/themes/uc-theme.css
@@ -4,7 +4,7 @@
 
 [data-theme="uc-theme"] {
   --theme-background: var(--palette-uc-blanco);
-  --theme-foreground: var(--palette-uc-negro);
+  --theme-foreground: var(--palette-uc-blue-primary);
   
   --theme-primary: var(--palette-uc-celeste);
   --theme-primary-foreground: var(--palette-uc-blanco);
@@ -29,9 +29,9 @@
   --theme-ring: var(--palette-uc-azul-oscuro);
 
   /* Functional colors for app-specific features */
-  --theme-route-primary: var(--palette-pastel-lavender);
-  --theme-route-border: var(--palette-pastel-lilac);
-  --theme-focus-indicator: var(--palette-uc-celeste);
+  --theme-route-primary: var(--palette-uc-celeste);
+  --theme-route-border: var(--palette-uc-azul);
+  --theme-focus-indicator: var(--palette-uc-azul-oscuro);
 
   /* Chart Colors */
   --theme-chart-0: var(--palette-pink);


### PR DESCRIPTION
# Problema
1. El indicador de ubicación UC no se ve ya que no hace contraste con fondo blanco.

## Solución
1. Se coloca el color primario UC para poder ver adecuadamente la ubicación.

<img width="171" height="169" alt="image" src="https://github.com/user-attachments/assets/de810673-df04-4472-921a-2ba98d4a1661" />
