### PR TITLE
fix: N2, N8 missmatch

### DIFF
--- a/data/places.json
+++ b/data/places.json
@@ -7378,7 +7378,7 @@
         {
             "type": "Feature",
             "properties": {
-                "identifier": "N2",
+                "identifier": "N8",
                 "name": "N8",
                 "campus": "SJ",
                 "information": "",
@@ -7503,7 +7503,7 @@
         {
             "type": "Feature",
             "properties": {
-                "identifier": "N8",
+                "identifier": "N2",
                 "name": "N2",
                 "campus": "SJ",
                 "information": "",


### PR DESCRIPTION
# Problema
1. El identificador de la sala N2 estaba como N8 y viceversa

## Solución
1. Corrección manual de places.json

