### PR TITLE
docs: update contribution guidance for DTFD workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 <h4 align="center"> Ubicate UC </h4>
 
+> [!IMPORTANT]
+> La rama principal para contribuir es `DTFD`. `main` está descontinuada temporalmente por unos meses.
+> Para más detalles sobre el proceso de contribución, revisa [contributing.md](contributing.md).
+
 <p align="center">
   <a href="#Descripción">Descripción</a> •
   <a href="#Uso">Uso</a> •
@@ -344,9 +348,11 @@ Utilice las **issues** para informar cualquier bug o solicitud.
 
 ### Workflow
 
-> PR a development -> Revisar preview y checks -> Asignar reviewers -> Aprobación -> Merge a development
+> PR a `DTFD` -> Revisar preview y checks -> Asignar reviewers -> Aprobación -> Merge a `DTFD`
 
-La información detallada sobre cómo contribuir se puede encontrar en [contributing.md](contributing.md).
+> [!IMPORTANT]
+> La branch oficial para contribuir es `DTFD`. `main` no estará activa por unos meses.
+> Para más detalles sobre el proceso de contribución, revisa [contributing.md](contributing.md).
 
 ## Necesitas contactarnos
 

--- a/contributing.md
+++ b/contributing.md
@@ -1,88 +1,43 @@
 # Contributing
 
-## Workflow (Flujo de trabajo)
-1. (Opcional) Discutir tu propuesta previamente creando una issue.
-2. Hacer _fork_ del repositorio para hacer tus cambios, o si tienes los permisos, crear una nueva branch bajo el mismo repositorio.
-   <details><summary>Si ya tienes un fork, debes sincronizar tu repositorio con upstream:</summary>
-   <ul>
-    <li>Hacer un pull request y merge desde la branch `development` de este repositorio hacia `development` de tu fork</li>
-    O
-    <li>Desde github, usar "fetch upstream" y "fetch and merge" para hacer lo mismo pero con menos pasos</li>
-    </ul>
-</details>
+## Avisos importantes
 
-3. Crear una branch basada en la branch `development`, en lo posible dale un nombre significativo a tu nueva branch, ej `add-project-images`.
+- La rama oficial para contribuir es `DTFD`.
+- `main` no estará activa por algunos meses, así que no la uses como base ni como destino de PR.
+- Todo PR debe ser aprobado por la universidad antes de integrarse.
+- Las contribuciones que agreguen funcionalidades pueden quedar en espera hasta esa aprobación.
+- No modifiques `places.json`.
+- Sigue `conventional commits` para los mensajes de commit.
+- Sigue `conventional branches` para el nombre de tus branches, por ejemplo `feat/...`, `fix/...` o `docs/...`.
 
-4. Crear un Pull Request (PR) a `development`, manteniéndolo como "borrador" (draft) hasta que esté listo para ser incorporado.
-5. Explicar brevemente los cambios, siguiendo el formato de Pull Requests, especificando posibles problemas o puntos de discusión.
-6. Solicitar una revisión de pares (*review*) a los integrantes del equipo del proyecto (los encuentras en la seccion de Maintainers del readme).
-7. Una vez aprobada la PR, un maintainer miembro del proyecto hará merge del código a `development`, una vez hecho el merge puedes eliminar tu branch.
+## Flujo de trabajo
 
+1. (Opcional) Abre una issue antes de trabajar en cambios grandes.
+2. Haz fork del repositorio, o crea una branch si tienes permisos sobre el repo.
+3. Sincroniza tu fork con `upstream` y toma `DTFD` como base.
+4. Crea una branch descriptiva desde `DTFD`, siguiendo `conventional branches`, por ejemplo `feat/add-project-images`.
+5. Sube tus cambios a tu fork y abre un PR contra `DTFD`.
+6. Mantén el PR en borrador si todavía está en revisión o le faltan ajustes.
+7. Describe claramente qué cambiaste, riesgos conocidos y cualquier dependencia externa.
+8. Solicita review al equipo del proyecto.
+9. Cuando el PR sea aprobado y mergeado, puedes borrar tu branch.
 
-## Tutorial
-### Como hacer Pull Requests
-Primero debe crear un `fork` del repositorio para poder realizar cambios en él.Se pueden encontrar mas detalles en [GitHub Documentation](https://docs.github.com/en/get-started/quickstart/fork-a-repo).
+## Checklist antes de abrir un PR
 
-Luego agrega tu fork como un proyecto local:
+- El cambio está basado en `DTFD`.
+- No tocaste `places.json`.
+- Tus commits siguen `conventional commits`.
+- Tu branch sigue `conventional branches`.
+- El PR explica el problema, la solución y posibles impactos.
+- Probaste localmente lo suficiente como para validar el cambio.
+- Si agregas una feature, entiendes que puede esperar aprobación de la universidad.
 
-```sh
-# Using HTTPS
-git clone https://github.com/YOUR-USERNAME/REPOSITORY-NAME
-
-# Using SSH
-git clone git@github.com:YOUR-USERNAME/REPOSITORY-NAME
-```
-
-> [Which remote URL should be used ?](https://docs.github.com/en/get-started/getting-started-with-git/about-remote-repositories)
-
-Luego, ve a tu carpeta local
+## Referencia rápida
 
 ```sh
-cd github-issue-template
+git remote add upstream <repo-url>
+git fetch upstream
+git switch DTFD
+git switch -c mi-cambio
+git push -u origin mi-cambio
 ```
-
-Agregue git remote controls:
-
-```sh
-# Using HTTPS
-git remote add fork https://github.com/YOUR-USERNAME/REPOSITORY-NAME
-git remote add upstream https://github.com/YOUR-USERNAME/REPOSITORY-NAME
-
-
-# Using SSH
-git remote add fork git@github.com:YOUR-USERNAME/REPOSITORY-NAME
-git remote add upstream git@github.com/YOUR-USERNAME/REPOSITORY-NAME
-```
-
-Ahora puede verificar que tienes dos remote controls:
-
-```sh
-git remote -v
-```
-
-### Realizar actualizaciones remotas
-Para mantenerse al día con el repositorio central:
-
-```sh
-git pull upstream main # or master
-```
-
-### Elija una branch de base
-Antes de comenzar el desarrollo, debe saber en qué branch basar sus modificaciones/adiciones. En caso de duda, use main o master.
-
-```sh
-# Cambiar a la branch deseada
-git switch main # master
-
-# Hacer pull de los cambios
-git pull
-
-# Crear una nueva branch para trabajar
-git switch --create patch/1234-name-issue
-```
-
-Comprometa tus cambios, luego realiza push a la rama a tu fork con `git push -u fork` y abra una pull request con la plantilla proporcionada.
-
-## Más información
-
-Puedes encontrar mas detalles sobre este proceso [aquí](https://docs.github.com/es/github/collaborating-with-issues-and-pull-requests/proposing-changes-to-your-work-with-pull-requests).


### PR DESCRIPTION
Document the current contribution rules for the repository.

- Clarify that DTFD is the official contribution branch
- Warn that main is temporarily inactive
- Require university approval for feature PRs
- Add conventional commits and conventional branches guidance
- Tell contributors not to modify places.json
- Point readers to contributing.md from the README
