### PR TITLE
feat: agregar nombres populares a los lugares

### DIFF
--- a/app/api/ubicate/route.ts
+++ b/app/api/ubicate/route.ts
@@ -54,6 +54,7 @@ export async function POST(request: NextRequest) {
     let nuevo_punto = createFeatureFromPoints(points, {
       identifier: "",
       name: result.data.data.name,
+      popularName: result.data.data.popularName,
       information: result.data.data.information,
       categories: result.data.data.categories,
       floors: result.data.data.floors,
@@ -150,6 +151,7 @@ export async function PUT(request: NextRequest) {
     let updated_point = createFeatureFromPoints(points, {
       identifier: result.data.identifier,
       name: result.data.data.name,
+      popularName: result.data.data.popularName,
       information: result.data.data.information,
       categories: result.data.data.categories,
       floors: result.data.data.floors,

--- a/app/components/features/filters/pills/placeFilters.ts
+++ b/app/components/features/filters/pills/placeFilters.ts
@@ -13,7 +13,9 @@ export const categoryFilter: PlaceFilter = (geoJson, query) => {
 };
 
 export const nameFilter: PlaceFilter = (geoJson, query) => {
-  return geoJson.features.filter((feature: { properties: { name: string } }) =>
-    feature.properties.name.toLowerCase().startsWith(query.toLowerCase()),
+  return geoJson.features.filter(
+    (feature: { properties: { name: string; popularName?: string } }) =>
+      feature.properties.name.toLowerCase().startsWith(query.toLowerCase()) ||
+      feature.properties.popularName?.toLowerCase().startsWith(query.toLowerCase()),
   );
 };

--- a/app/components/features/places/forms/PlaceForm.tsx
+++ b/app/components/features/places/forms/PlaceForm.tsx
@@ -13,10 +13,12 @@ import { DescriptionField } from "./descriptionField";
 import { FloorsField } from "./floorsField";
 import { Notification } from "./notification";
 import { PlaceNameField } from "./placeNameField";
+import { PopularNameField } from "./popularNameField";
 import { SubmitButton } from "./submitButton";
 
 interface PlaceFormData {
   name: string;
+  popularName: string;
   information: string;
   categories: string[];
   floors: (number | "")[];
@@ -33,6 +35,7 @@ export default function PlaceForm({
   onClose,
   defaultData = {
     name: "",
+    popularName: "",
     information: "",
     categories: [""],
     floors: [],
@@ -89,6 +92,12 @@ export default function PlaceForm({
         <PlaceNameField
           value={data.name}
           onChange={(value) => setData((prev) => ({ ...prev, name: value }))}
+          disabled={isLoading}
+        />
+
+        <PopularNameField
+          value={data.popularName}
+          onChange={(value) => setData((prev) => ({ ...prev, popularName: value }))}
           disabled={isLoading}
         />
 

--- a/app/components/features/places/forms/popularNameField.tsx
+++ b/app/components/features/places/forms/popularNameField.tsx
@@ -1,0 +1,28 @@
+interface PopularNameFieldProps {
+  value: string;
+  onChange: (value: string) => void;
+  disabled: boolean;
+}
+
+export function PopularNameField({ value, onChange, disabled }: PopularNameFieldProps) {
+  return (
+    <div className="space-y-4">
+      <label className="flex items-center justify-center text-md font-medium text-foreground" htmlFor="popularName">
+        Nombre popular (Opcional)
+      </label>
+      <p className="text-xs text-foreground/80 italic text-center">
+        Escribe el nombre coloquial por el que se conoce esta ubicación
+      </p>
+      <input
+        id="popularName"
+        type="text"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className="block p-3 w-full text-sm rounded-lg border border-border bg-input text-foreground focus:ring-primary focus:outline-hidden focus:ring-2 disabled:opacity-50 disabled:cursor-not-allowed"
+        placeholder="Ej: La pecera"
+        maxLength={100}
+        disabled={disabled}
+      />
+    </div>
+  );
+}

--- a/app/components/features/places/placeMenu/placeInformation.tsx
+++ b/app/components/features/places/placeMenu/placeInformation.tsx
@@ -230,11 +230,18 @@ export default function PlaceInformation({
               : null}
           </div>
 
-          {place.properties.information ? (
+          {place.properties.popularName || place.properties.information ? (
             <div className="space-y-3">
               <h4 className="text-lg font-semibold text-foreground">Descripción</h4>
-              <div className="rounded-xl border border-border/60 bg-muted/40 p-3">
-                <MarkDownComponent>{place.properties.information}</MarkDownComponent>
+              <div className="space-y-3 rounded-xl border border-border/60 bg-muted/40 p-3">
+                {place.properties.popularName ? (
+                  <p className="text-sm text-foreground">
+                    <span className="font-semibold">Nombre popular:</span> {place.properties.popularName}
+                  </p>
+                ) : null}
+                {place.properties.information ? (
+                  <MarkDownComponent>{place.properties.information}</MarkDownComponent>
+                ) : null}
               </div>
             </div>
           ) : null}

--- a/app/components/features/places/placeMenu/placeMenu.tsx
+++ b/app/components/features/places/placeMenu/placeMenu.tsx
@@ -120,6 +120,7 @@ export default function PlaceMenu({
         <PlaceForm
           defaultData={{
             name: editPlace?.properties.name ?? "",
+            popularName: editPlace?.properties.popularName ?? "",
             information: editPlace?.properties.information ?? "",
             categories: editPlace?.properties.categories ?? [],
             floors: editPlace?.properties.floors ?? [],

--- a/app/components/features/search/SearchDropdown.tsx
+++ b/app/components/features/search/SearchDropdown.tsx
@@ -27,7 +27,7 @@ export function SearchDropdown({ numberOfShowResults = 8 }: SearchDropdownProps)
 
   const fuse = useMemo(() => {
     return new Fuse(PlacesJSON.features, {
-      keys: ["properties.name"],
+      keys: ["properties.name", "properties.popularName"],
       threshold: 0.3,
     });
   }, []);

--- a/app/hooks/usePlaceForm.ts
+++ b/app/hooks/usePlaceForm.ts
@@ -9,6 +9,7 @@ import { NotificationState } from "../components/features/places/forms/notificat
 
 interface PlaceFormData {
   name: string;
+  popularName: string;
   information: string;
   categories: string[];
   floors: (number | "")[];
@@ -40,12 +41,14 @@ export function usePlaceForm(method: "POST" | "PUT", defaultData?: PlaceFormData
     defaultData
       ? {
           name: defaultData.name,
+          popularName: defaultData.popularName,
           information: defaultData.information,
           categories: defaultData.categories,
           floors: defaultData.floors,
         }
       : {
           name: "",
+          popularName: "",
           information: "",
           categories: [""],
           floors: [],

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -45,6 +45,7 @@ export enum CATEGORIES {
 export interface Properties {
   identifier: string;
   name: string;
+  popularName?: string;
   information: string;
   categories: string[]; // NO ES EL ENUM PUES EN EL PLACES.JSON PUES EN LA API DE CREAR LUGARES PASAN COSAS EXTRAÑAS Y HAY QUE ASEGURAR QUE PLACES.JSON SEA CONSISTENTE (TRABAJO A FUTURO 2026-08-03)
   campus: string;

--- a/lib/validation/schemas.ts
+++ b/lib/validation/schemas.ts
@@ -7,6 +7,7 @@ export const placeSchema = z.object({
       .string({ required_error: "El nombre es obligatorio" })
       .min(1, "El nombre no puede estar vacío")
       .max(100, "El nombre no puede exceder 100 caracteres"),
+    popularName: z.string().max(100, "El nombre popular no puede exceder 100 caracteres").optional(),
     information: z
       .string({ required_error: "La información es obligatoria" })
       .max(300, "La información no puede exceder 300 caracteres"),

--- a/tests/popularNameSearch.test.mjs
+++ b/tests/popularNameSearch.test.mjs
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { nameFilter } from "../app/components/features/filters/pills/placeFilters.ts";
+
+test("finds a place by its popular name", () => {
+  const canonicalPlace = {
+    properties: {
+      name: "Biblioteca de Humanidades",
+      popularName: "La pecera",
+    },
+  };
+
+  const matches = nameFilter({ features: [canonicalPlace] }, "la pec");
+
+  assert.deepEqual(matches, [canonicalPlace], "popular-name query should return the canonical place");
+});


### PR DESCRIPTION
## Resumen

- Permite proponer y editar un nombre popular opcional.
- Persiste el nombre popular mediante la API y lo incluye en las búsquedas.
- Muestra el nombre real en los resultados y el nombre popular en el detalle del lugar.

## Pruebas

- `OPENSSL_CONF=/dev/null NODE_NO_WARNINGS=1 node --experimental-strip-types --test tests/popularNameSearch.test.mjs` — la base falló y el commit corregido pasó en el verificador limpio sin red.
- `npm run lint` — pasó; conserva advertencias preexistentes de hooks/accesibilidad en archivos no modificados.
- `npx --no-install tsc --noEmit` — pasó.
- `npm run build` — compilación de producción completada con valores inertes para las variables de servicios externos requeridas.

## Alcance

- No se realizó ninguna escritura contra la API real de GitHub; la persistencia y la búsqueda están cubiertas por la prueba local enfocada y la compilación tipada.

Fixes #295

---
AI assistance was used. This change was reviewed by Northset, and I accept responsibility for this submission.

<!-- northset-receipt:M-1036:start -->
### Verification

[Northset proof-of-pass receipt M-1036](https://northset-oss.github.io/verification-pilot/receipts/M-1036/)  
Contributor self-run; not maintainer verification.
<!-- northset-receipt:M-1036:end -->
